### PR TITLE
OPS-865: Enable cloud watch logging for sendgrid kinesis firehose

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -57,7 +57,12 @@ class test_stack(object):
         assert s3_configuration['Prefix'] == 'firehose1'
         assert s3_configuration['BucketARN'] == 'arn:aws:s3:::bucket1'
 
-        cloud_watch_logging_options = s3_configuration['CloudWatchLoggingOptions']
-        assert cloud_watch_logging_options['Enabled'] == 'true'
-        assert cloud_watch_logging_options['LogGroupName'] == 'firehose-streams'
-        assert cloud_watch_logging_options['LogStreamName'] == 'firehose1'
+        s3_cloud_watch_logging_options = s3_configuration['CloudWatchLoggingOptions']
+        assert s3_cloud_watch_logging_options['Enabled'] == 'true'
+        assert s3_cloud_watch_logging_options['LogGroupName'] == 'firehose-streams'
+        assert s3_cloud_watch_logging_options['LogStreamName'] == 'firehose1'
+
+        redshift_cloud_watch_logging_options = redshift_destination_configuration['CloudWatchLoggingOptions']
+        assert redshift_cloud_watch_logging_options['Enabled'] == 'true'
+        assert redshift_cloud_watch_logging_options['LogGroupName'] == 'redshift-firehose'
+        assert redshift_cloud_watch_logging_options['LogStreamName'] == 'firehose1'

--- a/tropohelper/services.py
+++ b/tropohelper/services.py
@@ -52,7 +52,9 @@ def create_json_redshift_firehose_from_stream(stack, name, firehose_arn,
                                               redshift_db_table_name,
                                               s3_bucket_arn, s3_kms_key_arn, s3_role_arn,
                                               s3_buffering_seconds=300, s3_buffering_size=5,
-                                              s3_compression_format='GZIP', s3_log_group_name='firehose-streams'):
+                                              s3_compression_format='GZIP',
+                                              s3_log_group_name='firehose-streams',
+                                              redshift_log_group_name='redshift-firehose'):
     """Add Kinesus Redshift Firehose Resource with another Kinesis Stream as source and json as payload."""
     return stack.stack.add_resource(DeliveryStream(
         '{0}Firehose'.format(name.replace('-', '')),
@@ -63,6 +65,10 @@ def create_json_redshift_firehose_from_stream(stack, name, firehose_arn,
             RoleARN=source_stream_role_arn
         ),
         RedshiftDestinationConfiguration=RedshiftDestinationConfiguration(
+            CloudWatchLoggingOptions=CloudWatchLoggingOptions(
+                Enabled=True,
+                LogGroupName=redshift_log_group_name,
+                LogStreamName=name),
             ClusterJDBCURL=redshift_cluster_jdbc_url_param,
             CopyCommand=CopyCommand(
                 CopyOptions="JSON 'auto'",


### PR DESCRIPTION
We need to be able to log errors loading events into redshift. https://patientpop.atlassian.net/browse/OPS-865